### PR TITLE
[fix][修复结尾多一个92 05出现的问题]

### DIFF
--- a/utils/log_parser/functions/mlog_parser.m
+++ b/utils/log_parser/functions/mlog_parser.m
@@ -103,6 +103,9 @@ while ~feof(fileID) && ftell(fileID)<fileDir.bytes
     
     %%% Read Msg ID %%%
     msg_id = fread(fileID, 1, 'uint8=>uint8');
+    if isempty(msg_id) || feof(fileID)
+        break;
+    end
     
     % msg_id start from 0 and index start from 1
     index = msg_id + 1;


### PR DESCRIPTION
当mlog.bin文件的最后出现多余的帧头，就像这样
![image](https://github.com/user-attachments/assets/8504ec54-715f-447a-a884-9306f72bf119)
就会出现：
<img width="586" alt="63a7538d1339625334f17ccdb07b009" src="https://github.com/user-attachments/assets/c2eb0d7e-7aa4-4718-86c3-8c00682a7dbf" />
的错误；
虽然代码里面对index进行了检查，但是似乎不起作用；
你可以试一下我发给你的bin文件；
最后我只能套上try-cacth，解析才得以正常；